### PR TITLE
Make the samesite value on the login cookie case insensitive

### DIFF
--- a/src/api/operations/login.ts
+++ b/src/api/operations/login.ts
@@ -54,7 +54,9 @@ async function login({
     if (process.env.NODE_ENV !== 'production') {
       cookie = cookie.replace('; Secure', '')
       // SameSite=none can't be set unless the cookie is Secure
-      cookie = cookie.replace('; SameSite=none', '; SameSite=lax')
+      // bc seems to sometimes send back SameSite=None rather than none so make 
+      // this case insensitive
+      cookie = cookie.replace(/; SameSite=none/gi, '; SameSite=lax')
     }
 
     response.setHeader(


### PR DESCRIPTION
Big commerce sometimes returns a login cookie with SameSite set to None rather than none. The code to change this value in development mode needs to be case insensitive.

This was tried on a brand new setup store