### PR TITLE
Create useOrders hooks

### DIFF
--- a/src/api/orders/handlers/get-orders.ts
+++ b/src/api/orders/handlers/get-orders.ts
@@ -1,0 +1,20 @@
+import type { Order, OrdersHandlers } from '..'
+
+const getOrders: OrdersHandlers['getOrders'] = async ({
+  res,
+  body: { customer_id },
+  config,
+}) => {
+  let result: Order[] = []
+  if (customer_id) {
+    result = await config.storeApiFetch(`/v2/orders?customer_id=${customer_id}`, {
+      headers: {
+        Accept: "application/json",
+      }
+    })
+  }
+
+  res.status(200).json({ data: { orders: result } })
+}
+
+export default getOrders

--- a/src/api/orders/index.ts
+++ b/src/api/orders/index.ts
@@ -1,0 +1,140 @@
+import isAllowedMethod from '../utils/is-allowed-method'
+import createApiHandler, {
+  BigcommerceApiHandler,
+  BigcommerceHandler,
+} from '../utils/create-api-handler'
+import { BigcommerceApiError } from '../utils/errors'
+import getOrders from './handlers/get-orders'
+
+type FormField = {
+  name: string,
+  value: string,
+}
+
+// This type should match:
+// https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getallorders#responses
+export type Order = {
+  id: number,
+  date_modified: string,
+  date_shipped: string,
+  cart_id: string,
+  status: string,
+  subtotal_tax: string,
+  shipping_cost_tax: string,
+  shipping_cost_tax_class_id: number,
+  handling_cost_tax: string,
+  handling_cost_tax_class_id: number,
+  wrapping_cost_tax: string,
+  wrapping_cost_tax_class_id: number,
+  payment_status: "authorized" | "captured" | "capture pending" | "declined" | "held for review" | "paid" | "partially refunded" | "pending" | "refunded" | "void" | "void pending",
+  store_credit_amount:  string,
+  gift_certificate_amount: string,
+  currency_id:  number,
+  currency_code: string,
+  currency_exchange_rate:  string,
+  default_currency_id: number,
+  coupon_discount: string,
+  shipping_address_count: number,
+  is_email_opt_in:boolean,
+  order_source: string,
+  products: {
+    url: string,
+    resource: string,
+  },
+  shipping_addresses: {
+    url: string,
+    resource: string,
+  },
+  coupons: {
+    url: string,
+    resource: string,
+  },
+  status_id: number,
+  billing_address: {
+      first_name: string,
+      last_name: string,
+      company: string,
+      street_1: string,
+      street_2: string,
+      city: string,
+      state: string,
+      zip: number,
+      country: string,
+      country_iso2: string,
+      phone: number
+      email: string,
+      form_fields: FormField[],
+  },
+  subtotal_ex_tax: string,
+  subtotal_inc_tax: string,
+  base_shipping_cost:string,
+  shipping_cost_ex_tax: string,
+  shipping_cost_inc_tax: string,
+  base_handling_cost: string,
+  handling_cost_ex_tax: string,
+  handling_cost_inc_tax: string,
+  base_wrapping_cost: string,
+  wrapping_cost_ex_tax: string,
+  wrapping_cost_inc_tax:  string,
+  total_ex_tax: string,
+  total_inc_tax: string,
+  items_total:  number,
+  items_shipped: number,
+  payment_method: string,
+  payment_provider_id?: string | number,
+  refunded_amount: string,
+  order_is_digital: boolean,
+  ip_address: string,
+  geoip_country: string,
+  geoip_country_iso2:  string,
+  staff_notes: string,
+  customer_message: string,
+  discount_amount:  string,
+  is_deleted:  boolean,
+  ebay_order_id?:string,
+  external_source: string | null,
+  external_id:  string | null,
+  channel_id: number,
+  tax_provider_id: string,
+  date_created: string,
+  default_currency_code: string,
+}
+
+export type OrdersData = {
+  orders: Order[]
+}
+
+export type OrdersHandlers = {
+  getOrders: BigcommerceHandler<OrdersData, { customer_id?: string }>
+}
+
+const METHODS = ['GET']
+
+const ordersApi: BigcommerceApiHandler<
+  OrdersData,
+  OrdersHandlers
+> = async ( req, res, config, handlers) => {
+  if (!isAllowedMethod(req, res, METHODS)) return
+
+  try {
+    // Return current orders info
+    if (req.method === 'GET') {
+      const body = req.query
+      return await handlers['getOrders']({ req, res, config, body })
+    }
+
+  } catch (error) {
+    console.error(error)
+
+    const message =
+      error instanceof BigcommerceApiError
+        ? 'An unexpected error ocurred with the Bigcommerce API'
+        : 'An unexpected error ocurred'
+
+    res.status(500).json({ data: null, errors: [{ message }] })
+  }
+}
+
+export const handlers = { getOrders }
+
+export default createApiHandler(ordersApi, handlers, {})

--- a/src/use-orders.tsx
+++ b/src/use-orders.tsx
@@ -1,0 +1,61 @@
+import type { HookFetcher } from './commerce/utils/types'
+import type { SwrOptions } from './commerce/utils/use-data'
+import useData from './commerce/utils/use-data'
+
+import type { Order, OrdersData } from './api/orders'
+import useCustomer from './use-customer'
+
+const defaultOpts = {
+  url: '/api/bigcommerce/orders',
+  method: 'GET',
+}
+
+export type { Order }
+
+export interface UseOrdersInput {
+  customerId?: number
+}
+
+export const fetcher: HookFetcher<Order[] | null, UseOrdersInput> = async (
+  options,
+  { customerId },
+  fetch
+) => {
+  if (!customerId) return null
+
+  // Use a dummy base as we only care about the relative path
+  const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
+
+  url.searchParams.set('customer_id', String(customerId))
+  const data = await fetch<OrdersData | null>({
+    ...options,
+    url: url.pathname + url.search,
+    method: options?.method ?? defaultOpts.method,
+  })
+  return data?.orders ?? null
+}
+
+export function extendHook(
+  customFetcher: typeof fetcher,
+  swrOptions?: SwrOptions<Order[] | null, UseOrdersInput>
+) {
+  const useOrders = () => {
+    const { data: customer } = useCustomer()
+    return useData(defaultOpts,
+      [
+        ['customerId', customer?.entityId],
+      ],
+      customFetcher,
+      {
+        revalidateOnFocus: false,
+        ...swrOptions,
+      }
+    )
+  }
+
+  useOrders.extend = extendHook
+
+  return useOrders
+}
+
+export default extendHook(fetcher)


### PR DESCRIPTION
We need a way to return the orders that a user has made, for this I have created this new  `useOrders` hook.

- If the user is not logged in, nothing is returned.
- If the user is logged in, it returns an array with his orders.

I have asked in the [vercel/commerce repo](https://github.com/vercel/commerce/issues/215) which is the best approach to receive orders and while waiting for an answer I have implemented option 2.

Resolves #25 