### PR TITLE
Embedded checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Table of Contents
          * [useSearch](#usesearch)
          * [getAllProducts](#getallproducts)
          * [getProduct](#getproduct)
+      * [Checkout](#checkout)
       * [Troubleshooting](#troubleshooting)
       * [More](#more)
 
@@ -390,6 +391,19 @@ const { product } = await getProduct({
   preview,
 })
 ```
+
+## Checkout
+
+> The checkout only works on **production** and with a custom domain
+
+The recommended method is the [Embedded Checkout](https://developer.bigcommerce.com/api-docs/storefronts/embedded-checkout/embedded-checkout-tutorial), follow the tutorial to create a channel and a site. Notes:
+
+- The channel should be of type `storefront`
+- The site url must be your production url (e.g: https://mystore.com)
+- This package takes care of the cart and redirect links creation
+- Your bigcommerce store must be a subdomain of your headless store (eg: https://bc.mystore.com)
+
+![example image](https://cdn-std.droplr.net/files/acc_896732/sNjDtH)
 
 ## Troubleshooting
 <details>

--- a/src/api/checkout.ts
+++ b/src/api/checkout.ts
@@ -5,7 +5,7 @@ import createApiHandler, {
 import { BigcommerceApiError } from './utils/errors'
 
 const METHODS = ['GET']
-const fullCheckout = true
+const fullCheckout = false
 
 // TODO: a complete implementation should have schema validation for `req.body`
 const checkoutApi: BigcommerceApiHandler<any> = async (req, res, config) => {
@@ -32,7 +32,6 @@ const checkoutApi: BigcommerceApiHandler<any> = async (req, res, config) => {
       return
     }
 
-    // TODO: make the embedded checkout work too!
     const html = `
       <!DOCTYPE html>
         <html lang="en">

--- a/src/api/customers/handlers/login.ts
+++ b/src/api/customers/handlers/login.ts
@@ -5,6 +5,7 @@ import type { LoginHandlers } from '../login'
 const invalidCredentials = /invalid credentials/i
 
 const loginHandler: LoginHandlers['login'] = async ({
+  req,
   res,
   body: { email, password },
   config,
@@ -21,7 +22,7 @@ const loginHandler: LoginHandlers['login'] = async ({
   // and numeric characters.
 
   try {
-    await login({ variables: { email, password }, config, res })
+    await login({ variables: { email, password }, config, req, res })
   } catch (error) {
     // Check if the email and password didn't match an existing account
     if (

--- a/src/api/customers/handlers/logout.ts
+++ b/src/api/customers/handlers/logout.ts
@@ -2,14 +2,16 @@ import { serialize } from 'cookie'
 import { LogoutHandlers } from '../logout'
 
 const logoutHandler: LogoutHandlers['logout'] = async ({
+  req: request,
   res,
   body: { redirectTo },
   config,
 }) => {
+  const { host } = request.headers
   // Remove the cookie
   res.setHeader(
     'Set-Cookie',
-    serialize(config.customerCookie, '', { maxAge: -1, path: '/' })
+    serialize(config.customerCookie, '', { maxAge: -1, path: '/', domain: host?.includes(':') ? host?.slice(0, host.indexOf(':')) : host })
   )
 
   // Only allow redirects to a relative URL

--- a/src/api/customers/handlers/signup.ts
+++ b/src/api/customers/handlers/signup.ts
@@ -3,6 +3,7 @@ import login from '../../operations/login'
 import { SignupHandlers } from '../signup'
 
 const signup: SignupHandlers['signup'] = async ({
+  req,
   res,
   body: { firstName, lastName, email, password },
   config,
@@ -54,7 +55,7 @@ const signup: SignupHandlers['signup'] = async ({
   }
 
   // Login the customer right after creating it
-  await login({ variables: { email, password }, res, config })
+  await login({ variables: { email, password }, req, res, config })
 
   res.status(200).json({ data: null })
 }

--- a/src/api/customers/logout.ts
+++ b/src/api/customers/logout.ts
@@ -10,7 +10,7 @@ export type LogoutHandlers = {
   logout: BigcommerceHandler<null, { redirectTo?: string }>
 }
 
-const METHODS = ['GET']
+const METHODS = ['POST']
 
 const logoutApi: BigcommerceApiHandler<null, LogoutHandlers> = async (
   req,

--- a/src/api/operations/login.ts
+++ b/src/api/operations/login.ts
@@ -1,4 +1,6 @@
 import type { ServerResponse } from 'http'
+import type { NextApiRequest } from 'next'
+
 import type { LoginMutation, LoginMutationVariables } from '../../schema'
 import type { RecursivePartial } from '../utils/types'
 import concatHeader from '../utils/concat-cookie'
@@ -19,12 +21,14 @@ export type LoginVariables = LoginMutationVariables
 async function login(opts: {
   variables: LoginVariables
   config?: BigcommerceConfig
+  req: NextApiRequest
   res: ServerResponse
 }): Promise<LoginResult>
 
 async function login<T extends { result?: any }, V = any>(opts: {
   query: string
   variables: V
+  req: NextApiRequest
   res: ServerResponse
   config?: BigcommerceConfig
 }): Promise<LoginResult<T>>
@@ -32,11 +36,13 @@ async function login<T extends { result?: any }, V = any>(opts: {
 async function login({
   query = loginMutation,
   variables,
+  req: request,
   res: response,
   config,
 }: {
   query?: string
   variables: LoginVariables
+  req: NextApiRequest
   res: ServerResponse
   config?: BigcommerceConfig
 }): Promise<LoginResult> {
@@ -50,11 +56,15 @@ async function login({
   let cookie = res.headers.get('Set-Cookie')
 
   if (cookie && typeof cookie === 'string') {
+    const { host } = request.headers
+    // Set the a TLD cookie to make it accessible on subdomains
+    cookie = cookie + `; Domain=${host?.includes(':') ? host?.slice(0, host.indexOf(':')) : host}`
+
     // In development, don't set a secure cookie or the browser will ignore it
     if (process.env.NODE_ENV !== 'production') {
       cookie = cookie.replace('; Secure', '')
       // SameSite=none can't be set unless the cookie is Secure
-      // bc seems to sometimes send back SameSite=None rather than none so make 
+      // bc seems to sometimes send back SameSite=None rather than none so make
       // this case insensitive
       cookie = cookie.replace(/; SameSite=none/gi, '; SameSite=lax')
     }

--- a/src/api/operations/login.ts
+++ b/src/api/operations/login.ts
@@ -57,7 +57,7 @@ async function login({
 
   if (cookie && typeof cookie === 'string') {
     const { host } = request.headers
-    // Set the a TLD cookie to make it accessible on subdomains
+    // Set the cookie at TLD to make it accessible on subdomains
     cookie = cookie + `; Domain=${host?.includes(':') ? host?.slice(0, host.indexOf(':')) : host}`
 
     // In development, don't set a secure cookie or the browser will ignore it

--- a/src/use-logout.tsx
+++ b/src/use-logout.tsx
@@ -5,7 +5,7 @@ import useCustomer from './use-customer'
 
 const defaultOpts = {
   url: '/api/bigcommerce/customers/logout',
-  method: 'GET',
+  method: 'POST',
 }
 
 export const fetcher: HookFetcher<null> = (options, _, fetch) => {


### PR DESCRIPTION
I have enabled embedded checkout by keeping the user logged in, so now the checkout flow is smoother for authenticated users.

- Now the `SHOP_TOKEN` is set at TLD (Top Level Domain) so the subdomain (where the embedded checkout iframe lives) can access the token
- Added a new section in the readme with some notes about how to make the checkout works
- Modified the `logout` endpoint to be `POST` to prevent unwanted caching


Screencast: http://p.tri.be/zpiQ7i

Resolves #36
Resolves #6 