### PR TITLE
include physical_items.options response when adding items to cart

### DIFF
--- a/src/api/cart/handlers/add-item.ts
+++ b/src/api/cart/handlers/add-item.ts
@@ -29,8 +29,8 @@ const addItem: CartHandlers['addItem'] = async ({
     }),
   }
   const { data } = cartId
-    ? await config.storeApiFetch(`/v3/carts/${cartId}/items`, options)
-    : await config.storeApiFetch('/v3/carts', options)
+    ? await config.storeApiFetch(`/v3/carts/${cartId}/items?include=line_items.physical_items.options`, options)
+    : await config.storeApiFetch('/v3/carts?include=line_items.physical_items.options', options)
 
   // Create or update the cart cookie
   res.setHeader(


### PR DESCRIPTION
Added `include` query string to the end of the add item to cart request.