### PR TITLE
Add `useOrderProducts` hook

### DIFF
--- a/src/api/orders/handlers/get-order-products.ts
+++ b/src/api/orders/handlers/get-order-products.ts
@@ -1,0 +1,26 @@
+import type { Products, OrderProductHandlers } from "../products"
+
+const getOrderProducts: OrderProductHandlers["getOrderProducts"] = async ({
+	res,
+	body: { orderId },
+	config,
+}) => {
+	let result: Products = []
+	if (!orderId) {
+		// If the customerToken is invalid, then this request is too
+		return res.status(404).json({
+			data: null,
+			errors: [{ message: "Product order not found" }],
+		})
+	}
+
+	result = await config.storeApiFetch(`/v2/orders/${orderId}/products`, {
+		headers: {
+			Accept: "application/json",
+		},
+	})
+
+	res.status(200).json({ data: result ?? null })
+}
+
+export default getOrderProducts

--- a/src/api/orders/products.ts
+++ b/src/api/orders/products.ts
@@ -1,0 +1,126 @@
+import isAllowedMethod from "../utils/is-allowed-method"
+import createApiHandler, {
+	BigcommerceApiHandler,
+	BigcommerceHandler,
+} from "../utils/create-api-handler"
+import { BigcommerceApiError } from "../utils/errors"
+import getOrderProducts from "./handlers/get-order-products"
+
+// This type should match:
+// https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getallorders#responses
+
+interface AppliedDiscount {
+	id: string;
+	amount: string;
+	name: string;
+	code?: any;
+	target: string;
+}   
+
+interface ProductOption {
+	id: number;
+	option_id: number;
+	order_product_id: number;
+	product_option_id: number;
+	display_name: string;
+	display_name_customer: string;
+	display_name_merchant: string;
+	display_value: string;
+	display_value_customer: string;
+	display_value_merchant: string;
+	value: string;
+	type: string;
+	name: string;
+	display_style: string;
+}
+
+
+type Product = {
+	id: number;
+	order_id: number;
+	product_id: number;
+	order_address_id: number;
+	name: string;
+	name_customer: string;
+	name_merchant: string;
+	sku: string;
+	upc: string;
+	type: string;
+	base_price: string;
+	price_ex_tax: string;
+	price_inc_tax: string;
+	price_tax: string;
+	base_total: string;
+	total_ex_tax: string;
+	total_inc_tax: string;
+	total_tax: string;
+	weight: string;
+	quantity: number;
+	base_cost_price: string;
+	cost_price_inc_tax: string;
+	cost_price_ex_tax: string;
+	cost_price_tax: string;
+	is_refunded: boolean;
+	quantity_refunded: number;
+	refund_amount: string;
+	return_id: number;
+	wrapping_name: string;
+	base_wrapping_cost: string;
+	wrapping_cost_ex_tax: string;
+	wrapping_cost_inc_tax: string;
+	wrapping_cost_tax: string;
+	wrapping_message: string;
+	quantity_shipped: number;
+	fixed_shipping_cost: string;
+	ebay_item_id: string;
+	ebay_transaction_id: string;
+	option_set_id?: number;
+	parent_order_product_id?: number;
+	is_bundled_product: boolean;
+	bin_picking_number: string;
+	external_id?: any;
+	fulfillment_source: string;
+	applied_discounts: AppliedDiscount[];
+	product_options: ProductOption[];
+	configurable_fields: any[];
+	event_name?: any;
+	event_date?: any;
+}
+
+export type Products = Product[]
+
+export type OrderProductHandlers = {
+	getOrderProducts: BigcommerceHandler<Products, { orderId?: number }>
+}
+
+const METHODS = ["GET"]
+
+const orderProductsApi: BigcommerceApiHandler<Products, OrderProductHandlers> = async (
+	req,
+	res,
+	config,
+	handlers
+) => {
+	if (!isAllowedMethod(req, res, METHODS)) return
+
+	try {
+		// Return current orders info
+		if (req.method === "GET") {
+			const body = {
+				orderId: 20015,
+			}
+			return await handlers.getOrderProducts({ req, res, config, body })
+		}
+	} catch (error) {
+		const message =
+			error instanceof BigcommerceApiError
+				? "An unexpected error ocurred with the Bigcommerce API"
+				: "An unexpected error ocurred"
+
+		res.status(500).json({ data: null, errors: [{ message }] })
+	}
+}
+
+export const handlers = { getOrderProducts }
+
+export default createApiHandler(orderProductsApi, handlers, {})

--- a/src/api/orders/products.ts
+++ b/src/api/orders/products.ts
@@ -7,84 +7,299 @@ import { BigcommerceApiError } from "../utils/errors"
 import getOrderProducts from "./handlers/get-order-products"
 
 // This type should match:
-// https://developer.bigcommerce.com/api-reference/store-management/orders/orders/getallorders#responses
+// https://developer.bigcommerce.com/api-reference/store-management/orders/order-products/getallorderproducts#responses
 
-interface AppliedDiscount {
-	id: string;
-	amount: string;
-	name: string;
-	code?: any;
-	target: string;
-}   
-
-interface ProductOption {
-	id: number;
-	option_id: number;
-	order_product_id: number;
-	product_option_id: number;
-	display_name: string;
-	display_name_customer: string;
-	display_name_merchant: string;
-	display_value: string;
-	display_value_customer: string;
-	display_value_merchant: string;
-	value: string;
-	type: string;
-	name: string;
-	display_style: string;
+export interface Product {
+  /**
+   * Numeric ID of this product within this order.
+   */
+  id?: number
+  /**
+   * Numeric ID of the associated order.
+   */
+  order_id?: number
+  /**
+   * Numeric ID of the product.
+   */
+  product_id?: number
+  /**
+   * Numeric ID of the associated order address.
+   */
+  order_address_id?: number
+  /**
+   * Alias for name_customer - The product name that is shown to customer in storefront.
+   */
+  name?: string
+  /**
+   * User-defined product code/stock keeping unit (SKU).
+   */
+  sku?: string
+  /**
+   * Type of product
+   */
+  type?: "physical" | "digital"
+  /**
+   * The product's base price. (Float, Float-As-String, Integer)
+   */
+  base_price?: string
+  /**
+   * The product’s price excluding tax. (Float, Float-As-String, Integer)
+   */
+  price_ex_tax?: string
+  /**
+   * The product’s price including tax. (Float, Float-As-String, Integer)
+   */
+  price_inc_tax?: string
+  /**
+   * Amount of tax applied to a single product.
+   *
+   * Price tax is calculated as:
+   * `price_tax = price_inc_tax - price_ex_tax`
+   *
+   * (Float, Float-As-String, Integer)
+   */
+  price_tax?: string
+  /**
+   * Total base price. (Float, Float-As-String, Integer)
+   */
+  base_total?: string
+  /**
+   * Total base price excluding tax. (Float, Float-As-String, Integer)
+   */
+  total_ex_tax?: string
+  /**
+   * Total base price including tax. (Float, Float-As-String, Integer)
+   */
+  total_inc_tax?: string
+  /**
+   * Total tax applied to products.
+   * For example, if quantity if 2, base price is 5 and tax rate is 10%. price_tax will be $.50 and total_tax will be $1.00.
+   *
+   * If there is a manual discount applied total_tax is calcuted as the following:
+   * `(price_ex_tax - discount)*tax_rate=total_tax`.
+   * (Float, Float-As-String, Integer)
+   */
+  total_tax?: string
+  /**
+   * Quantity of the product ordered.
+   */
+  quantity?: number
+  /**
+   * The product's cost price.  This can be set using the Catalog API. (Float, Float-As-String, Integer) Read Only
+   */
+  base_cost_price?: string
+  /**
+   * The product's cost price including tax. (Float, Float-As-String, Integer)
+   * The cost of your products to you; this is never shown to customers, but can be used for accounting purposes. Read Only
+   */
+  cost_price_inc_tax?: string
+  /**
+   * The products cost price excluding tax. (Float, Float-As-String, Integer)
+   * The cost of your products to you; this is never shown to customers, but can be used for accounting purposes. Read Only
+   */
+  cost_price_ex_tax?: string
+  /**
+   * Weight of the product. (Float, Float-As-String, Integer)
+   */
+  weight?: number | string
+  /**
+   * Tax applied to the product’s cost price. (Float, Float-As-String, Integer)
+   * The cost of your products to you; this is never shown to customers, but can be used for accounting purposes. Read Only
+   */
+  cost_price_tax?: string
+  /**
+   * Whether the product has been refunded.
+   */
+  is_refunded?: boolean
+  /**
+   * The amount refunded from this transaction. (Float, Float-As-String, Integer)
+   */
+  refunded_amount?: string
+  /**
+   * Numeric ID for the refund.
+   */
+  return_id?: number
+  /**
+   * Name of gift-wrapping option
+   */
+  wrapping_name?: string
+  /**
+   * The value of the base wrapping cost. (Float, Float-As-String, Integer)
+   */
+  base_wrapping_cost?: string | number
+  /**
+   * The value of the wrapping cost, excluding tax. (Float, Float-As-String, Integer)
+   */
+  wrapping_cost_ex_tax?: string
+  /**
+   * The value of the wrapping cost, including tax. (Float, Float-As-String, Integer)
+   */
+  wrapping_cost_inc_tax?: string
+  /**
+   * Tax applied to gift-wrapping option. (Float, Float-As-String, Integer)
+   */
+  wrapping_cost_tax?: string
+  /**
+   * Message to accompany gift-wrapping option.
+   */
+  wrapping_message?: string
+  /**
+   * Quantity of this item shipped.
+   */
+  quantity_shipped?: number
+  /**
+   * Name of promotional event/delivery date.
+   */
+  event_name?: string | null
+  /**
+   * Date of the promotional event/scheduled delivery.
+   */
+  event_date?: string | null
+  /**
+   * Fixed shipping cost for this product. (Float, Float-As-String, Integer)
+   */
+  fixed_shipping_cost?: string
+  /**
+   * Item ID for this product on eBay.
+   */
+  ebay_item_id?: string
+  /**
+   * Transaction ID for this product on eBay.
+   */
+  ebay_transaction_id?: string
+  /**
+   * Numeric ID of the option set applied to the product.
+   */
+  option_set_id?: number | null
+  /**
+   * ID of a parent product.
+   */
+  parent_order_product_id?: number | null
+  /**
+   * Whether this product is bundled with other products.
+   */
+  is_bundled_product?: boolean
+  /**
+   * Bin picking number for the physical product.
+   */
+  bin_picking_number?: string
+  /**
+   * Array of objects containing discounts applied to the product.
+   */
+  applied_discounts?: ProductAppliedDiscount[]
+  /**
+   * Array of product option objects.
+   */
+  product_options?: ProductOption[]
+  /**
+   * ID of the order in another system. For example, the Amazon Order ID if this is an Amazon order.This field can be updated in a /POST, but using a /PUT to update the order will return a 400 error. The field 'external_id' cannot be written to. Please remove it from your request before trying again. It can not be overwritten once set.
+   */
+  external_id?: string | null
+  /**
+   * Universal Product Code. Can be written to for custom products and catalog products.
+   */
+  upc?: string
+  /**
+   * Products `variant_id`. PUT or POST. This field is not available for custom products.
+   */
+  variant_id?: number
+  /**
+   * The product name that is shown to customer in storefront.
+   */
+  name_customer?: string
+  /**
+   * The product name that is shown to merchant in Control Panel.
+   */
+  name_merchant?: string
 }
-
-
-type Product = {
-	id: number;
-	order_id: number;
-	product_id: number;
-	order_address_id: number;
-	name: string;
-	name_customer: string;
-	name_merchant: string;
-	sku: string;
-	upc: string;
-	type: string;
-	base_price: string;
-	price_ex_tax: string;
-	price_inc_tax: string;
-	price_tax: string;
-	base_total: string;
-	total_ex_tax: string;
-	total_inc_tax: string;
-	total_tax: string;
-	weight: string;
-	quantity: number;
-	base_cost_price: string;
-	cost_price_inc_tax: string;
-	cost_price_ex_tax: string;
-	cost_price_tax: string;
-	is_refunded: boolean;
-	quantity_refunded: number;
-	refund_amount: string;
-	return_id: number;
-	wrapping_name: string;
-	base_wrapping_cost: string;
-	wrapping_cost_ex_tax: string;
-	wrapping_cost_inc_tax: string;
-	wrapping_cost_tax: string;
-	wrapping_message: string;
-	quantity_shipped: number;
-	fixed_shipping_cost: string;
-	ebay_item_id: string;
-	ebay_transaction_id: string;
-	option_set_id?: number;
-	parent_order_product_id?: number;
-	is_bundled_product: boolean;
-	bin_picking_number: string;
-	external_id?: any;
-	fulfillment_source: string;
-	applied_discounts: AppliedDiscount[];
-	product_options: ProductOption[];
-	configurable_fields: any[];
-	event_name?: any;
-	event_date?: any;
+/**
+ * When applying a manual discount to an order (not a product level discount), the discount is distributed across products in proportion to the products price.
+ * `(total_manual_discount*price_ex_tax)/subtotal_ex_tax`
+ */
+interface ProductAppliedDiscount {
+  /**
+   * Name of the coupon applied to order.
+   */
+  id?: string
+  /**
+   * Amount of the discount.(Float, Float-As-String, Integer)
+   */
+  amount?: string
+  /**
+   * Name of the coupon.
+   * `Manual Discount` when creating a manual discount.
+   */
+  name?: string
+  /**
+   * Coupon Code.
+   * There is no code when creating a manual discount.
+   */
+  code?: string | null
+  /**
+   * Determines if the discount if discount was applied at the Order or Product level. Read Only.
+   */
+  target?: "order" | "product"
+  [k: string]: unknown
+}
+interface ProductOption {
+  /**
+   * The unique numerical ID of the option; increments sequentially.
+   */
+  id?: number
+  /**
+   * Numeric ID of the associated option.
+   */
+  option_id?: number
+  order_product_id?: number
+  product_option_id?: number
+  /**
+   * Alias for display_name_customer. The product option name that is shown to customer in the storefront.
+   */
+  display_name?: string
+  /**
+   * Alias for display_value_customer. The product option value that is shown to customer in storefront.
+   */
+  display_value?: string
+  /**
+   * This value is used to access the Customer File Upload.
+   */
+  value?: string
+  /**
+   * Option Type
+   */
+  type?:
+    | "Checkbox"
+    | "Date field"
+    | "File Upload"
+    | "Multi-line text field"
+    | "Multiple choice"
+    | "Product Pick List"
+    | "Swatch"
+    | "Text field"
+  /**
+   * The option’s name, as used internally. Must be unique.
+   */
+  name?: string
+  /**
+   * How it is displayed on the storefront. Examples include Drop-down, radio buttons, or rectangles.
+   */
+  display_style?: string
+  /**
+   * The product option name that is shown to customer in storefront.
+   */
+  display_name_customer?: string
+  /**
+   * The product option name that is shown to merchant in Control Panel.
+   */
+  display_name_merchant?: string
+  /**
+   * The product option value that is shown to customer in storefront.
+   */
+  display_value_customer?: string
+  /**
+   * The product option value that is shown to merchant in Control Panel.
+   */
+  display_value_merchant?: string
 }
 
 export type Products = Product[]
@@ -107,7 +322,7 @@ const orderProductsApi: BigcommerceApiHandler<Products, OrderProductHandlers> = 
 		// Return current orders info
 		if (req.method === "GET") {
 			const body = {
-				orderId: 20015,
+				orderId: Number(req.query.order_id)
 			}
 			return await handlers.getOrderProducts({ req, res, config, body })
 		}

--- a/src/use-order-products.tsx
+++ b/src/use-order-products.tsx
@@ -1,0 +1,46 @@
+import type { HookFetcher } from "./commerce/utils/types"
+import type { SwrOptions } from "./commerce/utils/use-data"
+import useData from "./commerce/utils/use-data"
+
+import type { Products } from "./api/orders/products"
+
+const defaultOpts = {
+	url: "/api/bigcommerce/order-products",
+	method: "GET",
+}
+
+export type { Products }
+
+export interface UseOrderProductsInput {
+	orderId?: number
+}
+
+export const fetcher: HookFetcher<
+	Products | null,
+	UseOrderProductsInput
+> = async (options, { orderId }, fetch) => {
+	if (!orderId) return null
+
+	return fetch<Products | null>({
+		...defaultOpts,
+		...options,
+	})
+}
+
+export function extendHook(
+	customFetcher: typeof fetcher,
+	swrOptions?: SwrOptions<Products | null, UseOrderProductsInput>
+) {
+	const useOrderProducts = ({ orderId }: UseOrderProductsInput) => {
+		return useData(defaultOpts, [["orderId", orderId]], customFetcher, {
+			revalidateOnFocus: false,
+			...swrOptions,
+		})
+	}
+
+	useOrderProducts.extend = extendHook
+
+	return useOrderProducts
+}
+
+export default extendHook(fetcher)

--- a/src/use-order-products.tsx
+++ b/src/use-order-products.tsx
@@ -5,7 +5,7 @@ import useData from "./commerce/utils/use-data"
 import type { Products } from "./api/orders/products"
 
 const defaultOpts = {
-	url: "/api/bigcommerce/order-products",
+	url: "/api/bigcommerce/orders/products",
 	method: "GET",
 }
 
@@ -20,10 +20,14 @@ export const fetcher: HookFetcher<
 	UseOrderProductsInput
 > = async (options, { orderId }, fetch) => {
 	if (!orderId) return null
+	// Use a dummy base as we only care about the relative path
+  const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
+	url.searchParams.set('order_id', String(orderId))
 
 	return fetch<Products | null>({
 		...defaultOpts,
 		...options,
+		url: url.pathname + url.search,
 	})
 }
 


### PR DESCRIPTION
Add a new `useOrderProducts` hook. Right now the `useOrders` hook doesn't include the products for each order due to limitations in the BigCommerce API. Thanks to this new hook you can get the products of a specific order.

API Reference: https://developer.bigcommerce.com/api-reference/store-management/orders/order-products/getallorderproducts

### Usage

```
import useOrderProduct from "@bigcommerce/storefront-data-hooks/use-order-products"

const { data } = useOrderProduct({ orderId: 20015 })
```
