### PR TITLE
Set prototype to BigCommerce Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 1.3.0
+### Login SSO Documentation
+
+-  Fix a bug in the Login SSO sample code: The `url` param must be passed inside the `options` object.
+
+### Add pagination to `useSearch`
+
+- Update `README.me`
+- Add a new param to the `useSearch` hook: `page`
+- Get the results based on the provided `page`.
+
+*Resolves [#38](https://github.com/bigcommerce/storefront-data-hooks/issues/38)*
+
+### Return `basePrice` in the product query
+
+- Return `basePrice` in the product query
+- Update GraphQL schema to generate the updated types (also includes updated types from the latest [Storefront GraphQL API](https://developer.bigcommerce.com/changelog#labels/storefront-api) updates)
+
+*Related to [#37](https://github.com/bigcommerce/storefront-data-hooks/issues/37)*
+
 # 1.2.0
 ### Embedded checkout
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ To authenticate a user using the Customer Login API, it's necessary to point the
 
 ```jsx
 const login = useLogin({
-  url: '/api/your-own-authentication',
+  options: {
+    url: '/api/your-own-authentication'
+  },
 })
 ```
 
@@ -337,7 +339,7 @@ const WishlistButton = ({ productId, variant }) => {
 
 ### useSearch
 
-`useSearch` handles searching the bigcommerce storefront product catalog by catalog, brand, and query string.
+`useSearch` handles searching the bigcommerce storefront product catalog by catalog, brand, and query string. It also allows pagination.
 
 ```jsx
 ...
@@ -349,13 +351,17 @@ const SearchPage = ({ searchString, category, brand, sortStr }) => {
     categoryId: category?.entityId,
     brandId: brand?.entityId,
     sort: sortStr || '',
+    page: 1
   })
+
+  const { products, pagination } = data
 
   return (
     <Grid layout="normal">
-      {data.products.map(({ node }) => (
+      {products.map(({ node }) => (
         <ProductCard key={node.path} product={node} />
       ))}
+      <Pagination {...pagination}>
     </Grid>
   )
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cookie": "0.4.1",
     "js-cookie": "2.2.1",
     "lodash.debounce": "4.0.8",
+    "lodash.omit": "^4.5.0",
     "swr": "0.3.6"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "@types/cookie": "^0.4.0",
     "@types/js-cookie": "^2.2.6",
     "@types/lodash.debounce": "^4.0.6",
+    "@types/lodash.omit": "^4.5.6",
     "@types/node": "^14.14.3",
     "@types/react": "^16.9.53",
     "graphql": "^15.4.0",

--- a/src/api/catalog/products.ts
+++ b/src/api/catalog/products.ts
@@ -5,17 +5,33 @@ import createApiHandler, {
 } from '../utils/create-api-handler'
 import { BigcommerceApiError } from '../utils/errors'
 import type { ProductEdge } from '../operations/get-all-products'
-import getProducts from './handlers/get-products'
+import getProducts, { Meta } from './handlers/get-products'
 
 export type SearchProductsData = {
   products: ProductEdge[]
   found: boolean
+  pagination: Omit<Meta["pagination"], "links" | "current_page"> & {
+    pages: {
+      /**
+       * The page you are currently on within the collection.
+       */
+      current: Meta["pagination"]["current_page"],
+      /**
+       * The previous page within the same collection
+       */
+      previous?: number,
+      /**
+       * The next page within the same collection
+       */
+      next?: number
+    }
+  }
 }
 
 export type ProductsHandlers = {
   getProducts: BigcommerceHandler<
     SearchProductsData,
-    { search?: 'string'; category?: string; categories?: string, brand?: string; sort?: string }
+    { search?: 'string'; category?: string; categories?: string, brand?: string; sort?: string, page?: string }
   >
 }
 

--- a/src/api/fragments/product.ts
+++ b/src/api/fragments/product.ts
@@ -12,6 +12,10 @@ export const productPrices = /* GraphQL */ `
       value
       currencyCode
     }
+    basePrice {
+      value
+      currencyCode
+    }
   }
 `
 

--- a/src/api/utils/errors.ts
+++ b/src/api/utils/errors.ts
@@ -1,7 +1,13 @@
 import type { Response } from '@vercel/fetch'
 
 // Used for GraphQL errors
-export class BigcommerceGraphQLError extends Error {}
+export class BigcommerceGraphQLError extends Error {
+  constructor(msg: string) {
+    super(msg)
+    // Necessary to compile to ES5: https://github.com/microsoft/TypeScript/issues/22585
+    Object.setPrototypeOf(this, BigcommerceGraphQLError.prototype);
+  }
+}
 
 export class BigcommerceApiError extends Error {
   status: number
@@ -10,6 +16,8 @@ export class BigcommerceApiError extends Error {
 
   constructor(msg: string, res: Response, data?: any) {
     super(msg)
+    // Necessary to compile to ES5: https://github.com/microsoft/TypeScript/issues/22585
+    Object.setPrototypeOf(this, BigcommerceApiError.prototype);
     this.name = 'BigcommerceApiError'
     this.status = res.status
     this.res = res
@@ -20,6 +28,8 @@ export class BigcommerceApiError extends Error {
 export class BigcommerceNetworkError extends Error {
   constructor(msg: string) {
     super(msg)
+    // Necessary to compile to ES5: https://github.com/microsoft/TypeScript/issues/22585
+    Object.setPrototypeOf(this, BigcommerceNetworkError.prototype);
     this.name = 'BigcommerceNetworkError'
   }
 }

--- a/src/products/use-search.tsx
+++ b/src/products/use-search.tsx
@@ -12,6 +12,7 @@ export type SearchProductsInput = {
   search?: string
   categoryId?: number
   categoryIds?: number[]
+  page?: number
   brandId?: number
   sort?: string
 }
@@ -21,13 +22,14 @@ export type SearchProductsPayload = Omit<SearchProductsInput, "categoryIds"> & {
 
 export const fetcher: HookFetcher<SearchProductsData, SearchProductsPayload> = (
   options,
-  { search, categoryId, stringifiedCategoryIds, brandId, sort },
+  { search, categoryId, stringifiedCategoryIds, brandId, sort, page },
   fetch
 ) => {
   // Use a dummy base as we only care about the relative path
   const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
 
   if (search) url.searchParams.set('search', search)
+  if (page) url.searchParams.set('page', String(page))
   if (Number.isInteger(categoryId))
     url.searchParams.set('category', String(categoryId))
   const categoryIds: SearchProductsInput["categoryIds"] = JSON.parse(stringifiedCategoryIds || '[]')
@@ -63,6 +65,7 @@ export function extendHook(
         ['stringifiedCategoryIds', JSON.stringify(input.categoryIds)],
         ['brandId', input.brandId],
         ['sort', input.sort],
+        ['page', input.page],
       ],
       customFetcher,
       { revalidateOnFocus: false, ...swrOptions }

--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -59,6 +59,13 @@ export type AggregatedInventory = {
   warningLevel: Scalars['Int']
 }
 
+/** Author */
+export type Author = {
+  __typename?: 'Author'
+  /** Author name. */
+  name: Scalars['String']
+}
+
 /** Brand */
 export type Brand = Node & {
   __typename?: 'Brand'
@@ -91,6 +98,7 @@ export type BrandProductsArgs = {
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** Brand */
@@ -246,6 +254,7 @@ export type CategoryProductsArgs = {
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** Category */
@@ -430,6 +439,26 @@ export type DisplayField = {
   extendedDateFormat: Scalars['String']
 }
 
+/** Distance */
+export type Distance = {
+  __typename?: 'Distance'
+  /** Distance in specified length unit */
+  value: Scalars['Float']
+  /** Length unit */
+  lengthUnit: LengthUnit
+}
+
+/** Filter locations by the distance */
+export type DistanceFilter = {
+  /** Radius of search in length units specified in lengthUnit argument */
+  radius: Scalars['Float']
+  /** Signed decimal degrees without compass direction */
+  longitude: Scalars['Float']
+  /** Signed decimal degrees without compass direction */
+  latitude: Scalars['Float']
+  lengthUnit: LengthUnit
+}
+
 /** A form allowing selection and uploading of a file from the user's local computer. */
 export type FileUploadFieldOption = CatalogProductOption & {
   __typename?: 'FileUploadFieldOption'
@@ -490,6 +519,8 @@ export type InventoryLocationsArgs = {
   entityIds?: Maybe<Array<Scalars['Int']>>
   codes?: Maybe<Array<Scalars['String']>>
   typeIds?: Maybe<Array<Scalars['String']>>
+  serviceTypeCodes?: Maybe<Array<Scalars['String']>>
+  distanceFilter?: Maybe<DistanceFilter>
   before?: Maybe<Scalars['String']>
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
@@ -507,6 +538,20 @@ export type InventoryByLocations = {
   warningLevel: Scalars['Int']
   /** Indicates whether this product is in stock. */
   isInStock: Scalars['Boolean']
+  /** Distance between location and specified longitude and latitude */
+  locationDistance?: Maybe<Distance>
+  /** Location type id. */
+  locationEntityTypeId?: Maybe<Scalars['String']>
+  /** Location service type codes. */
+  locationEntityServiceTypeCodes: Array<Scalars['String']>
+  /** Location code. */
+  locationEntityCode: Scalars['String']
+}
+
+/** length unit */
+export enum LengthUnit {
+  Miles = 'Miles',
+  Kilometres = 'Kilometres',
 }
 
 /** A connection to a list of items. */
@@ -722,7 +767,7 @@ export type PriceRanges = {
 /** The various prices that can be set on a product. */
 export type Prices = {
   __typename?: 'Prices'
-  /** Calculated price of the product. */
+  /** Calculated price of the product.  Calculated price takes into account basePrice, salePrice, rules (modifier, option, option set) that apply to the product configuration, and customer group discounts.  It represents the in-cart price for a product configuration without bulk pricing rules. */
   price: Money
   /** Sale price of the product. */
   salePrice?: Maybe<Money>
@@ -767,7 +812,10 @@ export type Product = Node & {
   maxPurchaseQuantity?: Maybe<Scalars['Int']>
   /** Absolute URL path for adding a product to cart. */
   addToCartUrl: Scalars['String']
-  /** Absolute URL path for adding a product to customer's wishlist. */
+  /**
+   * Absolute URL path for adding a product to customer's wishlist.
+   * @deprecated Deprecated.
+   */
   addToWishlistUrl: Scalars['String']
   /** Prices object determined by supplied product ID, variant ID, and selected option IDs. */
   prices?: Maybe<Prices>
@@ -822,11 +870,19 @@ export type Product = Node & {
   inventory: ProductInventory
   /** Metafield data related to a product. */
   metafields: MetafieldConnection
+  /** Universal product code. */
+  upc?: Maybe<Scalars['String']>
+  /** Manufacturer part number. */
+  mpn?: Maybe<Scalars['String']>
+  /** Global trade item number. */
+  gtin?: Maybe<Scalars['String']>
   /**
    * Product creation date
    * @deprecated Alpha version. Do not use in production.
    */
   createdAt: DateTimeExtended
+  /** Reviews associated with the product. */
+  reviews: ReviewConnection
 }
 
 /** Product */
@@ -908,6 +964,14 @@ export type ProductRelatedProductsArgs = {
 export type ProductMetafieldsArgs = {
   namespace: Scalars['String']
   keys?: Maybe<Array<Scalars['String']>>
+  before?: Maybe<Scalars['String']>
+  after?: Maybe<Scalars['String']>
+  first?: Maybe<Scalars['Int']>
+  last?: Maybe<Scalars['Int']>
+}
+
+/** Product */
+export type ProductReviewsArgs = {
   before?: Maybe<Scalars['String']>
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
@@ -1103,9 +1167,49 @@ export type RelatedProductsEdge = {
   cursor: Scalars['String']
 }
 
+/** Review */
+export type Review = {
+  __typename?: 'Review'
+  /** Unique ID for the product review. */
+  entityId: Scalars['Long']
+  /** Product review author. */
+  author: Author
+  /** Product review title. */
+  title: Scalars['String']
+  /** Product review text. */
+  text: Scalars['String']
+  /** Product review rating. */
+  rating: Scalars['Int']
+  /** Product review creation date. */
+  createdAt: DateTimeExtended
+}
+
+/** A connection to a list of items. */
+export type ReviewConnection = {
+  __typename?: 'ReviewConnection'
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<ReviewEdge>>>
+}
+
+/** An edge in a connection. */
+export type ReviewEdge = {
+  __typename?: 'ReviewEdge'
+  /** The item at the end of the edge. */
+  node: Review
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String']
+}
+
 /** Review Rating Summary */
 export type Reviews = {
   __typename?: 'Reviews'
+  /**
+   * Average rating of the product.
+   * @deprecated Alpha version. Do not use in production.
+   */
+  averageRating: Scalars['Float']
   /** Total number of reviews on product. */
   numberOfReviews: Scalars['Int']
   /** Summation of rating scores from each review. */
@@ -1138,6 +1242,7 @@ export type Settings = {
   display: DisplayField
   /** Channel ID. */
   channelId: Scalars['Long']
+  tax?: Maybe<TaxDisplaySettings>
 }
 
 /** A site */
@@ -1179,6 +1284,7 @@ export type SiteProductsArgs = {
   last?: Maybe<Scalars['Int']>
   ids?: Maybe<Array<Scalars['ID']>>
   entityIds?: Maybe<Array<Scalars['Int']>>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** A site */
@@ -1187,6 +1293,7 @@ export type SiteNewestProductsArgs = {
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** A site */
@@ -1195,6 +1302,7 @@ export type SiteBestSellingProductsArgs = {
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** A site */
@@ -1203,6 +1311,7 @@ export type SiteFeaturedProductsArgs = {
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
+  hideOutOfStock?: Maybe<Scalars['Boolean']>
 }
 
 /** A site */
@@ -1246,6 +1355,21 @@ export type SwatchOptionValue = CatalogProductOptionValue & {
 export type SwatchOptionValueImageUrlArgs = {
   width: Scalars['Int']
   height?: Maybe<Scalars['Int']>
+}
+
+export type TaxDisplaySettings = {
+  __typename?: 'TaxDisplaySettings'
+  /** Tax display setting for Product Details Page. */
+  pdp: TaxPriceDisplay
+  /** Tax display setting for Product List Page. */
+  plp: TaxPriceDisplay
+}
+
+/** Tax setting can be set included or excluded (Tax setting can also be set to both on PDP/PLP). */
+export enum TaxPriceDisplay {
+  Inc = 'INC',
+  Ex = 'EX',
+  Both = 'BOTH',
 }
 
 /** A single line text input field. */
@@ -1297,6 +1421,12 @@ export type Variant = Node & {
   inventory?: Maybe<VariantInventory>
   /** Metafield data related to a variant. */
   metafields: MetafieldConnection
+  /** Universal product code. */
+  upc?: Maybe<Scalars['String']>
+  /** Manufacturer part number. */
+  mpn?: Maybe<Scalars['String']>
+  /** Global trade item number. */
+  gtin?: Maybe<Scalars['String']>
 }
 
 /** Variant */
@@ -1363,13 +1493,17 @@ export type VariantInventory = {
 /** Variant Inventory */
 export type VariantInventoryByLocationArgs = {
   locationEntityIds?: Maybe<Array<Scalars['Int']>>
+  locationEntityCodes?: Maybe<Array<Scalars['String']>>
+  locationEntityTypeIds?: Maybe<Array<Scalars['String']>>
+  locationEntityServiceTypeCodes?: Maybe<Array<Scalars['String']>>
+  distanceFilter?: Maybe<DistanceFilter>
   before?: Maybe<Scalars['String']>
   after?: Maybe<Scalars['String']>
   first?: Maybe<Scalars['Int']>
   last?: Maybe<Scalars['Int']>
 }
 
-/** Please select a currency */
+/** Currency Code */
 export enum CurrencyCode {
   Adp = 'ADP',
   Aed = 'AED',
@@ -1425,6 +1559,7 @@ export enum CurrencyCode {
   Buk = 'BUK',
   Bwp = 'BWP',
   Byb = 'BYB',
+  Byn = 'BYN',
   Byr = 'BYR',
   Bzd = 'BZD',
   Cad = 'CAD',
@@ -1442,6 +1577,8 @@ export enum CurrencyCode {
   Crc = 'CRC',
   Csd = 'CSD',
   Csk = 'CSK',
+  Cuc = 'CUC',
+  Cup = 'CUP',
   Cve = 'CVE',
   Cyp = 'CYP',
   Czk = 'CZK',
@@ -1494,6 +1631,7 @@ export enum CurrencyCode {
   Inr = 'INR',
   Iqd = 'IQD',
   Isj = 'ISJ',
+  Irr = 'IRR',
   Isk = 'ISK',
   Itl = 'ITL',
   Jmd = 'JMD',
@@ -1503,6 +1641,7 @@ export enum CurrencyCode {
   Kgs = 'KGS',
   Khr = 'KHR',
   Kmf = 'KMF',
+  Kpw = 'KPW',
   Krh = 'KRH',
   Kro = 'KRO',
   Krw = 'KRW',
@@ -1690,6 +1829,9 @@ export type ProductPricesFragment = { __typename?: 'Prices' } & {
     { __typename?: 'Money' } & Pick<Money, 'value' | 'currencyCode'>
   >
   retailPrice?: Maybe<
+    { __typename?: 'Money' } & Pick<Money, 'value' | 'currencyCode'>
+  >
+  basePrice?: Maybe<
     { __typename?: 'Money' } & Pick<Money, 'value' | 'currencyCode'>
   >
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -54,6 +54,16 @@ type AggregatedInventory {
 }
 
 """
+Author
+"""
+type Author {
+  """
+  Author name.
+  """
+  name: String!
+}
+
+"""
 Brand
 """
 type Brand implements Node {
@@ -106,6 +116,7 @@ type Brand implements Node {
     after: String
     first: Int
     last: Int
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -360,6 +371,7 @@ type Category implements Node {
     after: String
     first: Int
     last: Int
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -695,6 +707,42 @@ type DisplayField {
 }
 
 """
+Distance
+"""
+type Distance {
+  """
+  Distance in specified length unit
+  """
+  value: Float!
+
+  """
+  Length unit
+  """
+  lengthUnit: LengthUnit!
+}
+
+"""
+Filter locations by the distance
+"""
+input DistanceFilter {
+  """
+  Radius of search in length units specified in lengthUnit argument
+  """
+  radius: Float!
+
+  """
+  Signed decimal degrees without compass direction
+  """
+  longitude: Float!
+
+  """
+  Signed decimal degrees without compass direction
+  """
+  latitude: Float!
+  lengthUnit: LengthUnit!
+}
+
+"""
 A form allowing selection and uploading of a file from the user's local computer.
 """
 type FileUploadFieldOption implements CatalogProductOption {
@@ -777,9 +825,11 @@ type Inventory {
   Locations
   """
   locations(
-    entityIds: [Int!]
-    codes: [String!]
-    typeIds: [String!]
+    entityIds: [Int!] = []
+    codes: [String!] = []
+    typeIds: [String!] = []
+    serviceTypeCodes: [String!] = []
+    distanceFilter: DistanceFilter
     before: String
     after: String
     first: Int
@@ -810,6 +860,34 @@ type InventoryByLocations {
   Indicates whether this product is in stock.
   """
   isInStock: Boolean!
+
+  """
+  Distance between location and specified longitude and latitude
+  """
+  locationDistance: Distance
+
+  """
+  Location type id.
+  """
+  locationEntityTypeId: String
+
+  """
+  Location service type codes.
+  """
+  locationEntityServiceTypeCodes: [String!]!
+
+  """
+  Location code.
+  """
+  locationEntityCode: String!
+}
+
+"""
+length unit
+"""
+enum LengthUnit {
+  Miles
+  Kilometres
 }
 
 """
@@ -1172,7 +1250,7 @@ The various prices that can be set on a product.
 """
 type Prices {
   """
-  Calculated price of the product.
+  Calculated price of the product.  Calculated price takes into account basePrice, salePrice, rules (modifier, option, option set) that apply to the product configuration, and customer group discounts.  It represents the in-cart price for a product configuration without bulk pricing rules.
   """
   price: Money!
 
@@ -1279,12 +1357,19 @@ type Product implements Node {
   """
   Absolute URL path for adding a product to customer's wishlist.
   """
-  addToWishlistUrl: String!
+  addToWishlistUrl: String! @deprecated(reason: "Deprecated.")
 
   """
   Prices object determined by supplied product ID, variant ID, and selected option IDs.
   """
-  prices(includeTax: Boolean = false, currencyCode: currencyCode): Prices
+  prices(
+    includeTax: Boolean = false
+
+    """
+    Please select a currency
+    """
+    currencyCode: currencyCode
+  ): Prices
 
   """
   The minimum and maximum price of this product based on variant pricing and/or modifier price rules.
@@ -1435,10 +1520,35 @@ type Product implements Node {
   ): MetafieldConnection!
 
   """
+  Universal product code.
+  """
+  upc: String
+
+  """
+  Manufacturer part number.
+  """
+  mpn: String
+
+  """
+  Global trade item number.
+  """
+  gtin: String
+
+  """
   Product creation date
   """
   createdAt: DateTimeExtended!
     @deprecated(reason: "Alpha version. Do not use in production.")
+
+  """
+  Reviews associated with the product.
+  """
+  reviews(
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ReviewConnection!
 }
 
 """
@@ -1757,9 +1867,80 @@ type RelatedProductsEdge {
 }
 
 """
+Review
+"""
+type Review {
+  """
+  Unique ID for the product review.
+  """
+  entityId: Long!
+
+  """
+  Product review author.
+  """
+  author: Author!
+
+  """
+  Product review title.
+  """
+  title: String!
+
+  """
+  Product review text.
+  """
+  text: String!
+
+  """
+  Product review rating.
+  """
+  rating: Int!
+
+  """
+  Product review creation date.
+  """
+  createdAt: DateTimeExtended!
+}
+
+"""
+A connection to a list of items.
+"""
+type ReviewConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ReviewEdge]
+}
+
+"""
+An edge in a connection.
+"""
+type ReviewEdge {
+  """
+  The item at the end of the edge.
+  """
+  node: Review!
+
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+}
+
+"""
 Review Rating Summary
 """
 type Reviews {
+  """
+  Average rating of the product.
+  """
+  averageRating: Float!
+    @deprecated(reason: "Alpha version. Do not use in production.")
+
   """
   Total number of reviews on product.
   """
@@ -1824,6 +2005,7 @@ type Settings {
   Channel ID.
   """
   channelId: Long!
+  tax: TaxDisplaySettings
 }
 
 """
@@ -1853,6 +2035,7 @@ type Site {
     last: Int
     ids: [ID!] = []
     entityIds: [Int!] = []
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -1863,6 +2046,7 @@ type Site {
     after: String
     first: Int
     last: Int
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -1873,6 +2057,7 @@ type Site {
     after: String
     first: Int
     last: Int
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -1883,6 +2068,7 @@ type Site {
     after: String
     first: Int
     last: Int
+    hideOutOfStock: Boolean
   ): ProductConnection!
 
   """
@@ -1945,6 +2131,30 @@ type SwatchOptionValue implements CatalogProductOptionValue {
   Indicates whether this value is the chosen default selected value.
   """
   isDefault: Boolean!
+}
+
+"""
+
+"""
+type TaxDisplaySettings {
+  """
+  Tax display setting for Product Details Page.
+  """
+  pdp: TaxPriceDisplay!
+
+  """
+  Tax display setting for Product List Page.
+  """
+  plp: TaxPriceDisplay!
+}
+
+"""
+Tax setting can be set included or excluded (Tax setting can also be set to both on PDP/PLP).
+"""
+enum TaxPriceDisplay {
+  INC
+  EX
+  BOTH
 }
 
 """
@@ -2049,7 +2259,14 @@ type Variant implements Node {
   """
   Variant prices
   """
-  prices(includeTax: Boolean = false, currencyCode: currencyCode): Prices
+  prices(
+    includeTax: Boolean = false
+
+    """
+    Please select a currency
+    """
+    currencyCode: currencyCode
+  ): Prices
 
   """
   Variant inventory
@@ -2067,6 +2284,21 @@ type Variant implements Node {
     first: Int
     last: Int
   ): MetafieldConnection!
+
+  """
+  Universal product code.
+  """
+  upc: String
+
+  """
+  Manufacturer part number.
+  """
+  mpn: String
+
+  """
+  Global trade item number.
+  """
+  gtin: String
 }
 
 """
@@ -2118,6 +2350,10 @@ type VariantInventory {
   """
   byLocation(
     locationEntityIds: [Int!] = []
+    locationEntityCodes: [String!] = []
+    locationEntityTypeIds: [String!] = []
+    locationEntityServiceTypeCodes: [String!] = []
+    distanceFilter: DistanceFilter
     before: String
     after: String
     first: Int
@@ -2126,7 +2362,7 @@ type VariantInventory {
 }
 
 """
-Please select a currency
+Currency Code
 """
 enum currencyCode {
   ADP
@@ -2183,6 +2419,7 @@ enum currencyCode {
   BUK
   BWP
   BYB
+  BYN
   BYR
   BZD
   CAD
@@ -2200,6 +2437,8 @@ enum currencyCode {
   CRC
   CSD
   CSK
+  CUC
+  CUP
   CVE
   CYP
   CZK
@@ -2252,6 +2491,7 @@ enum currencyCode {
   INR
   IQD
   ISJ
+  IRR
   ISK
   ITL
   JMD
@@ -2261,6 +2501,7 @@ enum currencyCode {
   KGS
   KHR
   KMF
+  KPW
   KRH
   KRO
   KRW

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.omit@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.omit/-/lodash.omit-4.5.6.tgz#f2a9518259e481a48ff7ec423420fa8fd58933e2"
+  integrity sha512-KXPpOSNX2h0DAG2w7ajpk7TXvWF28ZHs5nJhOJyP0BQHkehgr948RVsToItMme6oi0XJkp19CbuNXkIX8FiBlQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.162"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.162.tgz#65d78c397e0d883f44afbf1f7ba9867022411470"
@@ -3280,6 +3287,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
 lodash.once@^4.0.0:
   version "4.1.1"


### PR DESCRIPTION
Programmatically set the prototype to be able to check if a thrown Error is a BigCommerce Error. This is necessary because our compile target is ES5. Related issue: https://github.com/microsoft/TypeScript/issues/22585

Resolves a bug where the user couldn't add new products to the cart because the current cart was invalid but never deleted.

Resolves #49 