### PR TITLE
Get `locale`  with `useCommerce` instead of `useRouter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "next": ">=10",
     "react": ">=17"
   }
 }

--- a/src/cart/use-add-item.tsx
+++ b/src/cart/use-add-item.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
-import { useRouter } from 'next/router'
 import type { HookFetcher } from '.././commerce/utils/types'
 import { CommerceError } from '.././commerce/utils/errors'
 import useCartAddItem from '.././commerce/cart/use-add-item'
 import type { ItemBody, AddItemBody } from '../api/cart'
+import { useCommerce } from '..'
 import useCart, { Cart } from './use-cart'
 
 const defaultOpts = {
@@ -37,7 +37,7 @@ export const fetcher: HookFetcher<Cart, AddItemBody> = (
 export function extendHook(customFetcher: typeof fetcher) {
   const useAddItem = () => {
     const { mutate } = useCart()
-    const { locale } = useRouter()
+    const { locale } = useCommerce()
     const fn = useCartAddItem(defaultOpts, customFetcher)
 
     return useCallback(


### PR DESCRIPTION
Right now, in the `useAddItem`, we use `useRouter` to get locale require `next` as peer dependency which isn't optimal. This was introduced in version [v1.2.0](https://github.com/bigcommerce/storefront-data-hooks/releases/tag/v1.2.0)  when adding locale support to the cart https://github.com/bigcommerce/storefront-data-hooks/pull/41.

Now the `locale` will be obtained from the `useCommerce` as is done in other hooks such as `usePrice`.
https://github.com/bigcommerce/storefront-data-hooks/blob/e6196b04ca86239987148878e305f61c05f58902/src/commerce/use-price.tsx#L54

