### PR TITLE
Support query params in cart hooks

### DIFF
--- a/src/api/cart/handlers/add-item.ts
+++ b/src/api/cart/handlers/add-item.ts
@@ -5,7 +5,7 @@ import type { CartHandlers } from '..'
 // Return current cart info
 const addItem: CartHandlers['addItem'] = async ({
   res,
-  body: { cartId, locale, item },
+  body: { cartId, locale, item, include },
   config,
 }) => {
   if (!item) {
@@ -15,6 +15,10 @@ const addItem: CartHandlers['addItem'] = async ({
     })
   }
   if (!item.quantity) item.quantity = 1
+
+  // Use a dummy base as we only care about the relative path
+  const url = new URL(cartId ? `/v3/carts/${cartId}/items` : '/v3/carts', 'http://a')
+  if (include) url.searchParams.set('include', include)
 
   const options = {
     method: 'POST',
@@ -28,9 +32,7 @@ const addItem: CartHandlers['addItem'] = async ({
         : {}),
     }),
   }
-  const { data } = cartId
-    ? await config.storeApiFetch(`/v3/carts/${cartId}/items`, options)
-    : await config.storeApiFetch('/v3/carts', options)
+  const { data } = await config.storeApiFetch(url.pathname + url.search, options)
 
   // Create or update the cart cookie
   res.setHeader(

--- a/src/api/cart/handlers/get-cart.ts
+++ b/src/api/cart/handlers/get-cart.ts
@@ -5,14 +5,18 @@ import type { Cart, CartHandlers } from '..'
 // Return current cart info
 const getCart: CartHandlers['getCart'] = async ({
   res,
-  body: { cartId },
+  body: { cartId, include },
   config,
 }) => {
   let result: { data?: Cart } = {}
 
   if (cartId) {
     try {
-      result = await config.storeApiFetch(`/v3/carts/${cartId}`)
+      // Use a dummy base as we only care about the relative path
+      const url = new URL(`/v3/carts/${cartId}`, 'http://a')
+      if (include) url.searchParams.set('include', include)
+
+      result = await config.storeApiFetch(url.pathname + url.search)
     } catch (error) {
       if (error instanceof BigcommerceApiError && error.status === 404) {
         // Remove the cookie if it exists but the cart wasn't found

--- a/src/api/cart/handlers/remove-item.ts
+++ b/src/api/cart/handlers/remove-item.ts
@@ -4,7 +4,7 @@ import type { CartHandlers } from '..'
 // Return current cart info
 const removeItem: CartHandlers['removeItem'] = async ({
   res,
-  body: { cartId, itemId },
+  body: { cartId, itemId, include },
   config,
 }) => {
   if (!cartId || !itemId) {
@@ -14,8 +14,12 @@ const removeItem: CartHandlers['removeItem'] = async ({
     })
   }
 
+  // Use a dummy base as we only care about the relative path
+  const url = new URL(`/v3/carts/${cartId}/items/${itemId}`, 'http://a')
+  if (include) url.searchParams.set('include', include)
+
   const result = await config.storeApiFetch<{ data: any } | null>(
-    `/v3/carts/${cartId}/items/${itemId}`,
+    url.pathname + url.search,
     { method: 'DELETE' }
   )
   const data = result?.data ?? null

--- a/src/api/cart/handlers/update-item.ts
+++ b/src/api/cart/handlers/update-item.ts
@@ -5,7 +5,7 @@ import type { CartHandlers } from '..'
 // Return current cart info
 const updateItem: CartHandlers['updateItem'] = async ({
   res,
-  body: { cartId, itemId, item },
+  body: { cartId, itemId, item, include },
   config,
 }) => {
   if (!cartId || !itemId || !item) {
@@ -15,8 +15,12 @@ const updateItem: CartHandlers['updateItem'] = async ({
     })
   }
 
+  // Use a dummy base as we only care about the relative path
+  const url = new URL(`/v3/carts/${cartId}/items/${itemId}`, 'http://a')
+  if (include) url.searchParams.set('include', include)
+
   const { data } = await config.storeApiFetch(
-    `/v3/carts/${cartId}/items/${itemId}`,
+    url.pathname + url.search,
     {
       method: 'PUT',
       body: JSON.stringify({

--- a/src/api/cart/index.ts
+++ b/src/api/cart/index.ts
@@ -128,6 +128,11 @@ export type Cart = {
   created_time: string
   updated_time: string
   channel_id: number
+  redirect_urls?: {
+    cart_url: string
+    checkout_url: string
+    embedded_checkout_url?: string
+  }
 }
 
 export type CartHandlers = {

--- a/src/api/cart/index.ts
+++ b/src/api/cart/index.ts
@@ -21,11 +21,11 @@ export type ItemBody = {
 	optionSelections?: OptionSelections
 }
 
-export type AddItemBody = { item: ItemBody, locale?: string }
+export type AddItemBody = { item: ItemBody, locale?: string, include?: string }
 
-export type UpdateItemBody = { itemId: string; item: ItemBody }
+export type UpdateItemBody = { itemId: string; item: ItemBody, include?: string  }
 
-export type RemoveItemBody = { itemId: string }
+export type RemoveItemBody = { itemId: string, include?: string  }
 
 export type Coupon = {
   code: string
@@ -131,7 +131,7 @@ export type Cart = {
 }
 
 export type CartHandlers = {
-  getCart: BigcommerceHandler<Cart, { cartId?: string }>
+  getCart: BigcommerceHandler<Cart, { cartId?: string, include?: string }>
   addItem: BigcommerceHandler<Cart, { cartId?: string } & Partial<AddItemBody>>
   updateItem: BigcommerceHandler<
     Cart,
@@ -156,29 +156,30 @@ const cartApi: BigcommerceApiHandler<Cart, CartHandlers> = async (
 
   const { cookies } = req
   const cartId = cookies[config.cartCookie]
+  const include = typeof req.query.include === 'string' ? req.query.include : undefined
 
   try {
     // Return current cart info
     if (req.method === 'GET') {
-      const body = { cartId }
+      const body = { cartId, include }
       return await handlers['getCart']({ req, res, config, body })
     }
 
     // Create or add an item to the cart
     if (req.method === 'POST') {
-      const body = { ...req.body, cartId }
+      const body = { ...req.body, cartId, include }
       return await handlers['addItem']({ req, res, config, body })
     }
 
     // Update item in cart
     if (req.method === 'PUT') {
-      const body = { ...req.body, cartId }
+      const body = { ...req.body, cartId, include }
       return await handlers['updateItem']({ req, res, config, body })
     }
 
     // Remove an item from the cart
     if (req.method === 'DELETE') {
-      const body = { ...req.body, cartId }
+      const body = { ...req.body, cartId, include }
       return await handlers['removeItem']({ req, res, config, body })
     }
   } catch (error) {

--- a/src/cart/use-cart.tsx
+++ b/src/cart/use-cart.tsx
@@ -10,19 +10,24 @@ const defaultOpts = {
 
 export type { Cart }
 
+export type UseCartInput = {
+  include?:  ("redirect_urls" |"line_items.physical_items.options" |"line_items.digital_items.options")[]
+}
+
 export const fetcher: HookFetcher<Cart | null, CartInput> = (
   options,
-  { cartId },
+  { cartId, include },
   fetch
 ) => {
   if (!cartId) return null
   // Use a dummy base as we only care about the relative path
   const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
+  if (include) url.searchParams.set('include', include)
 
   return fetch({
     ...defaultOpts,
     ...options,
-    url: (options?.base || '') + url.pathname
+    url: (options?.base || '') + url.pathname + url.search,
   })
 }
 
@@ -30,8 +35,10 @@ export function extendHook(
   customFetcher: typeof fetcher,
   swrOptions?: SwrOptions<Cart | null, CartInput>
 ) {
-  const useCart = () => {
-    const response = useCommerceCart(defaultOpts, [], customFetcher, {
+  const useCart = (input?: UseCartInput) => {
+    const response = useCommerceCart(defaultOpts, [
+      ['include', input?.include?.join(',')]
+    ], customFetcher, {
       revalidateOnFocus: false,
       ...swrOptions,
     })

--- a/src/cart/use-remove-item.tsx
+++ b/src/cart/use-remove-item.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { HookFetcher } from '.././commerce/utils/types'
 import useCartRemoveItem from '.././commerce/cart/use-remove-item'
 import type { RemoveItemBody } from '../api/cart'
-import useCart, { Cart } from './use-cart'
+import useCart, { Cart, UseCartInput } from './use-cart'
 
 const defaultOpts = {
   url: '/api/bigcommerce/cart',
@@ -15,22 +15,24 @@ export type RemoveItemInput = {
 
 export const fetcher: HookFetcher<Cart | null, RemoveItemBody> = (
   options,
-  { itemId },
+  { itemId, include },
   fetch
 ) => {
 
   // Use a dummy base as we only care about the relative path
   const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
+  if (include) url.searchParams.set('include', include)
+
   return fetch({
     ...defaultOpts,
     ...options,
-    url: (options?.base || '') + url.pathname,
+    url: (options?.base || '') + url.pathname + url.search,
     body: { itemId },
   })
 }
 
 export function extendHook(customFetcher: typeof fetcher) {
-  const useRemoveItem = (item?: any) => {
+  const useRemoveItem = (item?: any, input?: UseCartInput) => { // TODO; Item should be mandatory and types
     const { mutate } = useCart()
     const fn = useCartRemoveItem<Cart | null, RemoveItemBody>(
       defaultOpts,
@@ -38,8 +40,11 @@ export function extendHook(customFetcher: typeof fetcher) {
     )
 
     return useCallback(
-      async function removeItem(input: RemoveItemInput) {
-        const data = await fn({ itemId: input.id ?? item?.id })
+      async function removeItem({ id: itemId }: RemoveItemInput) {
+        const data = await fn({
+          itemId: itemId ?? item?.id,
+          include: input?.include?.join(',')
+        })
         await mutate(data, false)
         return data
       },

--- a/src/commerce/cart/use-cart.tsx
+++ b/src/commerce/cart/use-cart.tsx
@@ -10,6 +10,7 @@ export type CartResponse<Result> = responseInterface<Result, Error> & {
 
 export type CartInput = {
   cartId: string | undefined
+  include?: string
 }
 
 export default function useCart<Result>(


### PR DESCRIPTION
Allow to define at hook level the parameter `include`, to be able to include more elements in the cart response. This allows, for example, to receive the different options of the products added to the cart.

```js
const { data } = useCart({ include: ['line_items.physical_items.options']})
```

Based on: https://developer.bigcommerce.com/api-reference/store-management/carts/cart/getacart