### PR TITLE
Improve Extensibility 2

### DIFF
--- a/src/commerce/index.tsx
+++ b/src/commerce/index.tsx
@@ -25,6 +25,8 @@ export type CommerceContextValue = {
   fetcherRef: MutableRefObject<Fetcher<any>>
   locale: string
   cartCookie: string
+  base?: string
+  credentials?: RequestInit["credentials"]
 }
 
 export function CommerceProvider({ children, config }: CommerceProps) {
@@ -40,8 +42,10 @@ export function CommerceProvider({ children, config }: CommerceProps) {
       fetcherRef,
       locale: config.locale,
       cartCookie: config.cartCookie,
+      base: config.base,
+      credentials: config.credentials,
     }),
-    [config.locale, config.cartCookie]
+    [config.locale, config.cartCookie, config.base, config.credentials]
   )
 
   return <Commerce.Provider value={cfg}>{children}</Commerce.Provider>

--- a/src/commerce/utils/types.ts
+++ b/src/commerce/utils/types.ts
@@ -17,6 +17,7 @@ export type HookFetcherOptions = {
   url?: string
   method?: string
   base?: string
+  credentials?: RequestInit["credentials"]
 }
 
 export type HookInput = [string, string | number | boolean | undefined][]

--- a/src/commerce/utils/use-action.tsx
+++ b/src/commerce/utils/use-action.tsx
@@ -6,10 +6,10 @@ export default function useAction<T, Input = null>(
   options: HookFetcherOptions,
   fetcher: HookFetcher<T, Input>
 ) {
-  const { fetcherRef } = useCommerce()
+  const { fetcherRef, credentials, base } = useCommerce()
 
   return useCallback(
-    (input: Input) => fetcher(options, input, fetcherRef.current),
+    (input: Input) => fetcher({...options, credentials, base }, input, fetcherRef.current),
     [fetcher]
   )
 }

--- a/src/commerce/utils/use-data.tsx
+++ b/src/commerce/utils/use-data.tsx
@@ -17,7 +17,7 @@ export type UseData = <Result = any, Input = null>(
 ) => responseInterface<Result, CommerceError>
 
 const useData: UseData = (options, input, fetcherFn, swrOptions) => {
-  const { fetcherRef } = useCommerce()
+  const { fetcherRef, credentials, base } = useCommerce()
   const fetcher = async (
     url?: string,
     query?: string,
@@ -26,7 +26,7 @@ const useData: UseData = (options, input, fetcherFn, swrOptions) => {
   ) => {
     try {
       return await fetcherFn(
-        { url, query, method },
+        { url, query, method, base, credentials },
         // Transform the input array into an object
         args.reduce((obj, val, i) => {
           obj[input[i][0]!] = val

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,13 +26,13 @@ async function getError(res: Response) {
 export const bigcommerceConfig: CommerceConfig = {
   locale: 'en-us',
   cartCookie: 'bc_cartId',
-  async fetcher({ url, method = 'GET', variables, body: bodyObj }) {
+  async fetcher({ url, method = 'GET', variables, body: bodyObj, credentials }) {
     const hasBody = Boolean(variables || bodyObj)
     const body = hasBody
       ? JSON.stringify(variables ? { variables } : bodyObj)
       : undefined
     const headers = hasBody ? { 'Content-Type': 'application/json' } : undefined
-    const res = await fetch(url!, { method, body, headers })
+    const res = await fetch(url!, { method, body, headers, credentials })
 
     if (res.ok) {
       const { data } = await res.json()
@@ -47,7 +47,6 @@ export type BigcommerceConfig = Partial<CommerceConfig>
 
 export type BigcommerceProps = {
   children?: ReactNode
-  locale: string
 } & BigcommerceConfig
 
 export function CommerceProvider({ children, ...config }: BigcommerceProps) {


### PR DESCRIPTION
Continuation of the work started in #67.

- Allow to set the `base` at Provider level. Thus, if it is set, all requests will be made with that base URL.
- Allow to define the credentials that will be used in the network requests