### PR TITLE
Allow 204

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,7 @@ export const bigcommerceConfig: CommerceConfig = {
     const res = await fetch(url!, { method, body, headers })
 
     if (res.ok) {
+      if (res.status === 204) return null
       const { data } = await res.json()
       return data
     }


### PR DESCRIPTION
- Allow responses with http status code 204

With the current configuration, when receiving a 204 (no content) it tries to execute the `.json()` method and fails. With this change we prevent the call to that method if the status is 204.