### PR TITLE
Update cart after add, update or remove cart items

### DIFF
--- a/src/cart/use-add-item.tsx
+++ b/src/cart/use-add-item.tsx
@@ -41,7 +41,7 @@ export const fetcher: HookFetcher<Cart, AddItemBody> = (
 
 export function extendHook(customFetcher: typeof fetcher) {
   const useAddItem = (input?: UseCartInput) => {
-    const { mutate } = useCart()
+    const { mutate } = useCart(input)
     const { locale } = useCommerce()
     const fn = useCartAddItem(defaultOpts, customFetcher)
 

--- a/src/cart/use-add-item.tsx
+++ b/src/cart/use-add-item.tsx
@@ -47,7 +47,11 @@ export function extendHook(customFetcher: typeof fetcher) {
 
     return useCallback(
       async function addItem(item: AddItemInput) {
-        const data = await fn({ item, locale, include: input?.include?.join(',') })
+        const data = await fn({
+          item,
+          locale,
+          include: input?.include?.join(','),
+        })
         await mutate(data, false)
         return data
       },

--- a/src/cart/use-remove-item.tsx
+++ b/src/cart/use-remove-item.tsx
@@ -33,7 +33,7 @@ export const fetcher: HookFetcher<Cart | null, RemoveItemBody> = (
 
 export function extendHook(customFetcher: typeof fetcher) {
   const useRemoveItem = (item?: any, input?: UseCartInput) => { // TODO; Item should be mandatory and types
-    const { mutate } = useCart()
+    const { mutate } = useCart(input)
     const fn = useCartRemoveItem<Cart | null, RemoveItemBody>(
       defaultOpts,
       customFetcher

--- a/src/cart/use-remove-item.tsx
+++ b/src/cart/use-remove-item.tsx
@@ -18,7 +18,6 @@ export const fetcher: HookFetcher<Cart | null, RemoveItemBody> = (
   { itemId, include },
   fetch
 ) => {
-
   // Use a dummy base as we only care about the relative path
   const url = new URL(options?.url ?? defaultOpts.url, 'http://a')
   if (include) url.searchParams.set('include', include)
@@ -32,7 +31,8 @@ export const fetcher: HookFetcher<Cart | null, RemoveItemBody> = (
 }
 
 export function extendHook(customFetcher: typeof fetcher) {
-  const useRemoveItem = (item?: any, input?: UseCartInput) => { // TODO; Item should be mandatory and types
+  const useRemoveItem = (item?: any, input?: UseCartInput) => {
+    // TODO; Item should be mandatory and types
     const { mutate } = useCart(input)
     const fn = useCartRemoveItem<Cart | null, RemoveItemBody>(
       defaultOpts,
@@ -43,7 +43,7 @@ export function extendHook(customFetcher: typeof fetcher) {
       async function removeItem({ id: itemId }: RemoveItemInput) {
         const data = await fn({
           itemId: itemId ?? item?.id,
-          include: input?.include?.join(',')
+          include: input?.include?.join(','),
         })
         await mutate(data, false)
         return data

--- a/src/cart/use-update-item.tsx
+++ b/src/cart/use-update-item.tsx
@@ -59,7 +59,7 @@ function extendHook(customFetcher: typeof fetcher, cfg?: { wait?: number }) {
             variantId: newItem.variantId ?? item?.variant_id,
             quantity: newItem.quantity,
           },
-          include: input?.include?.join(',')
+          include: input?.include?.join(','),
         })
         await mutate(data, false)
         return data

--- a/src/cart/use-update-item.tsx
+++ b/src/cart/use-update-item.tsx
@@ -44,7 +44,7 @@ export const fetcher: HookFetcher<Cart | null, UpdateItemBody> = (
 
 function extendHook(customFetcher: typeof fetcher, cfg?: { wait?: number }) {
   const useUpdateItem = (item: PhysicalItem, input?: UseCartInput) => {
-    const { mutate } = useCart()
+    const { mutate } = useCart(input)
     const fn = useCartUpdateItem<Cart | null, UpdateItemBody>(
       defaultOpts,
       customFetcher
@@ -61,7 +61,6 @@ function extendHook(customFetcher: typeof fetcher, cfg?: { wait?: number }) {
           },
           include: input?.include?.join(',')
         })
-        console.log({ data })
         await mutate(data, false)
         return data
       }, cfg?.wait ?? 500),


### PR DESCRIPTION
Allow to pass array of options to `useAddItem`, `useUpdateItem ` and `useRemoveItem ` as it's allowed in `useCart`.

This way, when using the hook of `useCart` with options, we can update its value through the rest of hooks if the same options are used. This is because behind the scenes we use **`swr`** in which the hook update depends on its input arguments. And the cart options are input arguments.

Resolve #89 