### PR TITLE
feat: Adds hexColors to the schema for multiple choice options.

### DIFF
--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -969,6 +969,8 @@ export type MultipleChoiceOptionValue = CatalogProductOptionValue & {
   label: Scalars['String']
   /** Indicates whether this value is the chosen default selected value. */
   isDefault: Scalars['Boolean']
+  /** List of up to 3 hex encoded colors to associate with a swatch value. */
+  hexColors: Array<Scalars['String']>
 }
 
 /** An object with an ID */


### PR DESCRIPTION
###Description
Adds the `hexColors` Array to the MultipleChoiceOptionsValue schema so that it can be referenced within a component.