### PR TITLE
fix: BCP20-1283 Remove debounce from the useUpdateItem callback.

### DIFF
--- a/src/cart/use-update-item.tsx
+++ b/src/cart/use-update-item.tsx
@@ -51,7 +51,7 @@ function extendHook(customFetcher: typeof fetcher, cfg?: { wait?: number }) {
     )
 
     return useCallback(
-      debounce(async (newItem: UpdateItemInput) => {
+      async (newItem: UpdateItemInput) => {
         const data = await fn({
           itemId: newItem.id ?? item?.id,
           item: {
@@ -63,7 +63,7 @@ function extendHook(customFetcher: typeof fetcher, cfg?: { wait?: number }) {
         })
         await mutate(data, false)
         return data
-      }, cfg?.wait ?? 500),
+      },
       [fn, mutate]
     )
   }


### PR DESCRIPTION
### Description
Removes the debounce function wrapped around the callback for `useUpdateItem` to allow errors to pass through.

### Ticket
https://moderntribe.atlassian.net/browse/BCP20-1283

fixes #122