### PR TITLE
chore: build files to a dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,15 @@
 {
   "name": "@bigcommerce/storefront-data-hooks",
   "version": "1.8.0",
-  "main": "index.js",
+  "main": "dist/index.js",
   "repository": "git@github.com:bigcommerce/storefront-data-hooks.git",
   "license": "MIT",
   "files": [
-    "*.js",
-    "*.d.ts",
-    "address",
-    "api",
-    "cart",
-    "commerce",
-    "products",
-    "wishlist"
+    "dist"
   ],
   "scripts": {
-    "clean": "rimraf *.js *.d.ts api cart commerce products scripts wishlist address",
-    "build": "npm run clean && tsc && cp src/schema.d.ts schema.d.ts",
+    "clean": "rimraf dist",
+    "build": "npm run clean && tsc && cp src/schema.d.ts dist/schema.d.ts",
     "start": "npm run clean && tsc -w",
     "prepublish": "npm run build",
     "generate": "graphql-codegen -r dotenv/config",

--- a/src/api/utils/errors.ts
+++ b/src/api/utils/errors.ts
@@ -29,5 +29,6 @@ export class BigcommerceNetworkError extends Error {
     super()
 
     this.name = 'BigcommerceNetworkError'
+    this.message = msg
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "jsx": "react",
     "declaration": true,
-    "outDir": "./"
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["node_nodules"]


### PR DESCRIPTION
## What/why?

Rebased off of https://github.com/bigcommerce/storefront-data-hooks/pull/133

Builds and exports files to a `dist/` folder instead of the root repo. This makes the build/clean scripts easier to understand and is less polluting to the repo when developing.